### PR TITLE
Fix #33: Calculate timezone offset

### DIFF
--- a/ejira-hourmarking.el
+++ b/ejira-hourmarking.el
@@ -113,7 +113,8 @@
 (defun ejira-hourmarking-round (time round-by)
   "Round TIME to nearest ROUND-BY."
   ;; Account for stupid time zone issues.
-  (let* ((hours (- (string-to-number (format-time-string "%H" time)) 2))
+  (let* ((offset (/ (car (current-time-zone)) 3600))
+         (hours (- (string-to-number (format-time-string "%H" time)) offset))
          (minutes (string-to-number (format-time-string "%M" time)))
          (total (+ (* 60 hours) minutes))
          (rounded (round total round-by))


### PR DESCRIPTION
I took a shot at this. No idea if this is really a great solution but it seems to resolve the issue with the hard coded value.
`(current-time-zone)` returns something like `(3600 "CET)` where the first part is the time zone difference in seconds. 