### PR TITLE
support top-level org headers in the document

### DIFF
--- a/ejira-core.el
+++ b/ejira-core.el
@@ -242,7 +242,7 @@ The default value is applicable for:
                                   (find-file project-file-name))))
 
           (unless existing-heading
-            (ejira--new-heading project-buffer key))
+            (ejira--new-heading project-buffer nil key))
 
           (ejira--set-summary key (ejira-project-name project))
           (ejira--set-property key "TYPE" "ejira-project"))))))
@@ -310,7 +310,9 @@ If the issue heading does not exist, fallback to full update."
       ;; Create a new heading if needed
       (unless (ejira--find-heading key)
         (when (fboundp 'helm-ejira-invalidate-cache) (helm-ejira-invalidate-cache))
-        (ejira--new-heading (marker-buffer (ejira--find-heading project)) key))
+        (ejira--new-heading (marker-buffer (ejira--find-heading project))
+                            (or parent project)
+                            key))
 
       (ejira--set-todo-state key (alist-get status ejira-todo-states-alist 1 nil #'equal))
 
@@ -565,15 +567,19 @@ If LEVEL is given, shift all heading by it."
       (error nil))))
 
 
-(defun ejira--new-heading (buffer id)
-  "Create a header with id ID into BUFFER and return a marker to it.
-If TITLE is given, use it as header title."
+(defun ejira--new-heading (buffer parent id)
+  "Create a header with ID under PARENT into BUFFER and return a marker to it.
+If TITLE is given, use it as header title. If PARENT is nil assume the beginning
+of the document."
   (save-window-excursion
     (with-current-buffer buffer
       (org-with-wide-buffer
        (ejira--with-expand-all
          (goto-char (point-min))
 
+         ;; `forward-line' won't work as intended if the org document contains
+         ;; headers. We should jump to the parent.
+         (when parent (goto-char (ejira--find-heading parent)))
          ;; insert-heading-respect-content does not respect content if we are
          ;; before first heading in the file. Thus, we want to move to a safe
          ;; location. In an empty buffer, the first line has the visibility


### PR DESCRIPTION
Prior to this change, having org headers (such as `title`) would trip up
the creation of a new ticket, and that new ticket would override the
project heading. This meant the project couldn't be found in later calls
and would eventually lead to a "Target <project> not found", with the
document left slightly corrupted.

The fix here is to attempt to hang new headings from
`ejira--new-heading` off of a parent heading by jumping to that parent
heading, and then doing `forward-line` as we normally would. In the case
that a parent isn't provided, the project is used.

My organization's jira structure is relatively flat. I have tested these
changes both with and without top level headings and the problem is
resolved. I suggest testing against your own structure to ensure I
didn't break anything - though I have no reason to believe it will be
broken.
