### PR TITLE
Patch ejira-core to refer to users via accountId

### DIFF
--- a/ejira-core.el
+++ b/ejira-core.el
@@ -805,7 +805,7 @@ With SHALLOW update only todo state."
                      (mapcar (lambda (user)
                                (let ((name (decode-coding-string
                                             (cdr (assoc 'displayName user)) 'utf-8))
-                                     (key (cdr (assoc 'key user))))
+                                     (key (cdr (assoc 'accountId user))))
                                  (unless (s-starts-with? "#" key)
                                    (cons key name))))
                              (jiralib2-get-users (car ejira-projects))))))))
@@ -819,7 +819,7 @@ With SHALLOW update only todo state."
   (let* ((jira-users (ejira--get-users))
          (fullname (completing-read "User: " (mapcar 'cdr jira-users)))
          (username (car (rassoc fullname jira-users))))
-    (insert (format "[[jirauser:~%s]]" username))))
+    (insert (format "[[~accountid:%s]]" username))))
 
 (defun ejira--get-assignable-users (issue-key)
   "Fetch users that issue ISSUE-KEY can be assigned to."
@@ -829,7 +829,7 @@ With SHALLOW update only todo state."
            (mapcar (lambda (user)
                      (let ((name (decode-coding-string
                                   (cdr (assoc 'displayName user)) 'utf-8))
-                           (key (cdr (assoc 'name user))))
+                           (key (cdr (assoc 'accountId user))))
                        (unless (s-starts-with? "#" key)
                          (cons key name))))
                    (jiralib2-get-assignable-users issue-key)))))


### PR DESCRIPTION
Hi! Thank you for this nice piece of software.

It may be specific to configuration of my corporate jira (I mean, clearly if assigning issues and making mentions were not working at all, people would notice, although #37 mentions same GDPR error as I have).

It is very odd, but mentions format we have right now does not work for me, I did some experimenting involving
web browser and mentioning innocent people, and came to format I propose in this pull request.

I am not sure what is GDPR strict mode is, but probably referring to users by accoutId instead of full names is better in general, since it will less likely to break on people with complicated Unicode names or people with same names or something like this.

Closing this PR with `works fine for me` is okay; as I said this may be related to my particular instance of jira (I am not admin of it), but I though it would be nice to inform you about these issues.