### PR TITLE
Remove obsolete package dash-functional

### DIFF
--- a/ejira-core.el
+++ b/ejira-core.el
@@ -33,7 +33,6 @@
 (require 'org)
 (require 'f)
 (require 'dash)
-(require 'dash-functional)
 (require 'org-id)
 (require 'org-capture)
 

--- a/ejira-pkg.el
+++ b/ejira-pkg.el
@@ -4,7 +4,7 @@
     (s "1.0")
     (f "1.0")
     (ox-jira "1.0")
-    (dash "2.14.1")
+    (dash "2.19.1")
     (jiralib2 "1.0")
     (language-detection "1.0"))
   :keywords

--- a/ejira.el
+++ b/ejira.el
@@ -32,7 +32,7 @@
 ;;; Code:
 
 (require 'org)
-(require 'dash-functional)
+(require 'dash)
 (require 'ejira-core)
 
 

--- a/helm-ejira.el
+++ b/helm-ejira.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/nyyManni/ejira
 ;; Keywords: jira, org, helm
 ;; Version: 1.0
-;; Package-Requires: ((ejira "1.0") (helm "1.0") (org "8.3") (s "1.0") (dash "1.0"))
+;; Package-Requires: ((ejira "1.0") (helm "1.0") (org "8.3") (s "1.0") (dash "2.19.1"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
Thanks for this package

The package dash functional is obsolete as said in the custom repository  [dash-functional obsolete comment](https://github.com/magnars/dash.el/blob/0ac1ecf6b56eb67bb81a3cf70f8d4354b5782341/dash-functional.el#L46) (this causes problems when using ejira with doom emacs for example).

I updated all dash dependencies, hope this helps

 